### PR TITLE
use utf-8 without BOM

### DIFF
--- a/src/Tools/emacs-lsp/lsp-isar/lsp-isar.el
+++ b/src/Tools/emacs-lsp/lsp-isar/lsp-isar.el
@@ -373,7 +373,7 @@ mode automically, use `(add-hook \\='isar-mode-hook
 
 ;; although the communication to the LSP server is done using utf-16,
 ;; we can only use utf-8
-(modify-coding-system-alist 'file "\\.thy\\'" 'utf-8-auto)
+(modify-coding-system-alist 'file "\\.thy\\'" 'utf-8)
 
 (defun lsp-isar-activate-indentation ()
   "Activate automatic indentation by default."


### PR DESCRIPTION
This was defaulting newly created buffers to be encoded with utf-8 with BOM.
That caused encoding problems with some systems that expect isabelle files to begin with .`theory`.
